### PR TITLE
OS Awareness via `on(<platform>)`.

### DIFF
--- a/lib/wrkflo/step.rb
+++ b/lib/wrkflo/step.rb
@@ -1,3 +1,4 @@
+require 'os'
 require 'wrkflo/configurable'
 
 class Step
@@ -62,4 +63,17 @@ class Step
   def unrun
     log "Nothing to do."
   end
+
+
+  protected
+
+    # Return true if being run on the given platform. If a block is given, run
+    # the block only if being run on the given platform and return the result.
+    def on platform
+      if block_given?
+        yield if OS.send("#{platform}?")
+      else
+        return OS.send("#{platform}?")
+      end
+    end
 end

--- a/wrkflo.gemspec
+++ b/wrkflo.gemspec
@@ -10,11 +10,6 @@ Gem::Specification.new do |spec|
   spec.date                   = Date.today.strftime('%F')
   spec.summary                = 'Get working on things faster with predefined wrkflos.'
 
-  spec.required_ruby_version  = '>= 2.2.0'
-
-  spec.add_development_dependency "bundler", "~> 1.13"
-  spec.add_development_dependency "rake", "~> 10.0"
-
   spec.author                 = 'Jon Egeland'
   spec.email                  = 'jonegeland@gmail.com'
 
@@ -23,5 +18,13 @@ Gem::Specification.new do |spec|
   spec.homepage               = 'http://github.com/faultyserver/wrkflo'
   spec.license                = 'MIT'
 
+  spec.required_ruby_version  = '>= 2.2.0'
+
+  spec.add_dependency         "os", "~> 1.0"
+
   spec.executables            << 'wrkflo'
+
+
+  spec.add_development_dependency "bundler", "~> 1.13"
+  spec.add_development_dependency "rake", "~> 10.0"
 end


### PR DESCRIPTION
`on(<platform>)` returns true if execution is currently happening on the given platform. If a block is given, that block will be executed under the same condition.

OS detection is done via the `os` gem by rdp (https://github.com/rdp/os).