### PR TITLE
Configuration Enforcement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,9 @@
 Gemfile.lock
 .ruby-version
 .ruby-gemset
+
+# packaged gems from older versions
+releases/
+
+# Makefile for easier local installs
+Makefile

--- a/bin/wrkflo
+++ b/bin/wrkflo
@@ -7,14 +7,6 @@ require 'yaml'
 require 'wrkflo/wrkflo'
 
 
-# Abort execution with the given message, exiting with the given status code.
-def error_out message, status: 1
-  $stderr.puts message
-  $stderr.puts "Run `wrkflo --help` for usage information."
-  exit status
-end
-
-
 options = {
   backward: false,
   profile: ENV['HOME'] + '/.wrkflo/config',
@@ -42,13 +34,13 @@ OptionParser.new do |opts|
     # Without this rescue, Ruby would print the stack trace
     # of the error. Instead, we want to show the error message,
     # suggest -h or --help, and exit 1.
-    error_out(error)
+    Notifier.error_out(error)
   end
 end
 
 
 project_name = ARGV[0]
-error_out('No project specified.') if project_name.nil?
+Notifier.error_out('No project specified.') if project_name.nil?
 
 # An object representation of the entire wrkflo profile, merged with
 # the options given for this run.
@@ -57,7 +49,7 @@ wrkflo = WrkFlo.new(options)
 project = wrkflo[project_name]
 # If no project was specified, notify and exit
 if project == nil
-  error_out("Project '#{project_name}' does not exist in '#{wrkflo.profile_source}'.")
+  Notifier.error_out("Project '#{project_name}' does not exist in '#{wrkflo.profile_source}'.")
 end
 
 # Run the project workflow in the direction given from the terminal

--- a/lib/wrkflo/configurable.rb
+++ b/lib/wrkflo/configurable.rb
@@ -18,7 +18,7 @@ module Configurable
   end
 
 
-  def apply_configuration raw_config
+  def apply_configuration raw_config, validate: true
     final_config = self.class.properties.each.with_object({}) do |(name, prop), h|
       provided_value = raw_config[name.to_s]
       # Determine the real value based on the property's definition
@@ -29,6 +29,17 @@ module Configurable
 
     # Create a struct from the configuration hash to enable dot-access.
     @configuration = Struct.new(*final_config.keys).new(*final_config.values)
+    # Always validate the new configuration unless specifically told not to.
+    validate_configuration if validate
+  end
+
+  # Returns a truthy value if the configuration is valid, false otherwise.
+  def validate_configuration
+    self.class.properties.values.each do |prop|
+      if prop.required?
+        return false unless config.respond_to?(prop.name)
+      end
+    end
   end
 
   def config

--- a/lib/wrkflo/configurable.rb
+++ b/lib/wrkflo/configurable.rb
@@ -8,8 +8,8 @@ module Configurable
     end
 
     # Define a new property for the owning object
-    def property name, required: false, default: nil
-      properties[name] = Property.new(name, required, default)
+    def property name, required: false, type: Object, default: nil
+      properties[name] = Property.new(name, required, type, default)
     end
   end
 
@@ -18,7 +18,7 @@ module Configurable
   end
 
 
-  def apply_configuration raw_config, validate: true
+  def apply_configuration raw_config
     final_config = self.class.properties.each.with_object({}) do |(name, prop), h|
       provided_value = raw_config[name.to_s]
       # Determine the real value based on the property's definition
@@ -29,17 +29,25 @@ module Configurable
 
     # Create a struct from the configuration hash to enable dot-access.
     @configuration = Struct.new(*final_config.keys).new(*final_config.values)
-    # Always validate the new configuration unless specifically told not to.
-    validate_configuration if validate
   end
 
-  # Returns a truthy value if the configuration is valid, false otherwise.
+  # Returns `true` if the configuration is valid. Otherwise, returns a pair
+  # of the property and a reason. If a block is given, this pair is also
+  # passed to the block.
   def validate_configuration
     self.class.properties.values.each do |prop|
       if prop.required?
-        return false unless config.respond_to?(prop.name)
+        unless config.respond_to?(prop.name)
+          return [prop, nil, :required].tap{ |f| yield f if block_given? }
+        end
       end
+
+      value = config.send(prop.name)
+
+      return [prop, value, :type].tap{ |f| yield f if block_given? } unless prop.matches_type?(value)
     end
+
+    return true
   end
 
   def config

--- a/lib/wrkflo/configurable/property.rb
+++ b/lib/wrkflo/configurable/property.rb
@@ -5,20 +5,67 @@ module Configurable
     # Whether the property is required to be provided by the user
     attr_accessor :required
     alias_method  :required?, :required
+    # The expected type of the value
+    attr_accessor :type
     # The default value to be given to this property if one is not provided
     attr_accessor :default
 
 
-    def initialize name, is_required, default_value
+    def initialize name, is_required, expected_type, default_value
       @name     = name
       @required = is_required
       @default  = default_value
+      @type     = expected_type
     end
 
 
     # Assign a value to this property
     def resolve_value value
       value.nil? ? @default : value
+    end
+
+    # Returns true if `value` is of the type expected by this property. Returns
+    # false otherwise.
+    # For simple types, this is a simple `is_a?` check.
+    # For arrays, two different rules apply:
+    #   - `Array[]` expects an arbitrary array of values.
+    #   - `Array[Float]` expects an arbitrary-length array of `Float` values.
+    #   - `Array[Float, String, ...]` expects an Array of exactly those types.
+    def matches_type? value, expected_type: type
+      case expected_type
+      # Raw class types
+      when Array
+        case expected_type.length
+        when 0
+          return value.is_a?(Array)
+        when 1
+          return value.all?{ |v| matches_type?(v, expected_type: expected_type[0]) }
+        else
+          return expected_type.zip([value].flatten(1)).all?{ |t, v| matches_type?(v, expected_type: t) }
+        end
+      else
+        value.is_a?(expected_type)
+      end
+    end
+
+    def type_as_string expected_type: type
+      case expected_type
+      when Array
+        value_types = expected_type.map{ |t| t.to_s }
+        "Array[#{value_types.join(',')}]"
+      else
+        expected_type.to_s
+      end
+    end
+
+    def value_type_as_string value
+      case value
+      when Array
+        value_types = value.map{ |v| v.class.to_s }
+        "Array[#{value_types.join(',')}]"
+      else
+        value.class.to_s
+      end
     end
   end
 end

--- a/lib/wrkflo/notifier.rb
+++ b/lib/wrkflo/notifier.rb
@@ -1,0 +1,19 @@
+module Notifier
+  FOOTER_TEXT = <<-END_FOOTER
+Run `wrkflo --help` for usage information.
+  END_FOOTER
+
+  # Write an error message to stderr and abort execution, exiting with the
+  # given status code, or `1` if no status code is specified.
+  def self.error_out *messages, type: "Error", status: 1
+    $stderr.puts "#{type}: #{messages.first}"
+    messages.drop(1).each{ |msg| $stderr.puts "\t#{msg}" }
+    $stderr.puts FOOTER_TEXT
+    exit status
+  end
+
+  # Write an arbitrary message to stdout.
+  def self.log message
+    $stdout.puts message
+  end
+end

--- a/lib/wrkflo/profile.rb
+++ b/lib/wrkflo/profile.rb
@@ -3,9 +3,7 @@ class Profile
     @projects = YAML.load_file(source)
     @options = @projects.delete("options")
   rescue
-    $stderr.puts "Could not load configuration at '#{source}'."
-    $stderr.puts "Make sure the file exists before running `wrkflo`."
-    exit 1
+    Notifier.error_out("Could not load configuration at '#{source}'.", type: "ConfigurationError")
   end
 
   def self.projects;  @projects;  end

--- a/lib/wrkflo/steps/atom.rb
+++ b/lib/wrkflo/steps/atom.rb
@@ -1,7 +1,7 @@
 class AtomStep < Step
   add_alias :atom
 
-  property :path, required: true
+  property :path, required: true, type: String
 
   def run
     log "Opening an Atom Window at  #{config.path}"

--- a/lib/wrkflo/steps/editor.rb
+++ b/lib/wrkflo/steps/editor.rb
@@ -1,8 +1,8 @@
 class Editor < Step
   add_alias :editor
 
-  property :which,  required: false,  default: Profile.options['editor']
-  property :path,   required: true
+  property :which,  required: false,  type: String, default: Profile.options['editor']
+  property :path,   required: true,   type: String
 
   def init
     @editor = config.which

--- a/lib/wrkflo/steps/emacs.rb
+++ b/lib/wrkflo/steps/emacs.rb
@@ -1,7 +1,7 @@
 class EmacsStep < Step
   add_alias :emacs
 
-  property :path, required: true
+  property :path, required: true, type: String
 
   def run
     log "Opening an Emacs frame at #{config.path}"

--- a/lib/wrkflo/steps/filesystem.rb
+++ b/lib/wrkflo/steps/filesystem.rb
@@ -2,10 +2,10 @@ class FileSystem < Step
   add_alias :filesystem
   add_alias :fs
 
-  property :which,        required: false,  default: Profile.options['filesystem']
-  property :host,         required: true
-  property :remote_path,  required: true
-  property :local_path,   required: true
+  property :which,        required: false,  type: String, default: Profile.options['filesystem']
+  property :host,         required: true,   type: String
+  property :remote_path,  required: true,   type: String
+  property :local_path,   required: true,   type: String
 
   def init
     @filesystem = config.which

--- a/lib/wrkflo/steps/ssh.rb
+++ b/lib/wrkflo/steps/ssh.rb
@@ -1,8 +1,8 @@
 class SSHStep < Step
   add_alias :ssh
 
-  property :host,       required: true
-  property :directory,  required: true
+  property :host,       required: true, type: String
+  property :directory,  required: true, type: String
 
   def run
     log "SSHing into  #{config.host}  at  #{config.directory}"

--- a/lib/wrkflo/steps/sshfs.rb
+++ b/lib/wrkflo/steps/sshfs.rb
@@ -1,9 +1,9 @@
 class SSHFSStep < Step
   add_alias :sshfs
 
-  property :host,         required: true
-  property :remote_path,  required: true
-  property :local_path,   required: true
+  property :host,         required: true, type: String
+  property :remote_path,  required: true, type: String
+  property :local_path,   required: true, type: String
 
   def run
     log "Mounting  #{config.host}:#{config.remote_path}  at  #{config.local_path}"

--- a/lib/wrkflo/steps/sublime.rb
+++ b/lib/wrkflo/steps/sublime.rb
@@ -2,7 +2,7 @@ class SublimeStep < Step
   add_alias :sublime
   add_alias :subl
 
-  property :path, required: true
+  property :path, required: true, type: String
 
   def run
     log "Opening a Sublime Window at  #{config.path}"

--- a/lib/wrkflo/wrkflo.rb
+++ b/lib/wrkflo/wrkflo.rb
@@ -1,3 +1,4 @@
+require 'wrkflo/notifier'
 require 'wrkflo/version'
 require 'wrkflo/profile'
 require 'wrkflo/project'
@@ -44,7 +45,9 @@ class WrkFlo
     Project.new(project) if Profile.projects[project]
   end
 
+
   private
+
     def configured_step_paths
       Profile.options['step_definitions'] || []
     end


### PR DESCRIPTION
Implementation of the enforcement aspect of #4. The initial implementation was handled by #9.

This PR also introduces `Notifier`, a common interface for sending notifications to users. This is primarily useful for aborting on errors, but can also be used for general logging.