### PR TITLE
Use `WRKFLO` namespace.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Wrkflo
+# wrkflo
 
 `wrkflo` is a Ruby Gem that helps you get working on things faster with
 predefined wrkflos.

--- a/bin/wrkflo
+++ b/bin/wrkflo
@@ -4,7 +4,7 @@ require 'optparse'
 require 'pp'
 require 'yaml'
 
-require 'wrkflo/wrkflo'
+require 'wrkflo'
 
 
 options = {
@@ -15,7 +15,7 @@ options = {
 OptionParser.new do |opts|
   opts.banner     = "Usage: wrkflo [options] <project>"
   opts.separator  "Start working on things faster with predefined workflows"
-  opts.version    = Wrkflo::VERSION
+  opts.version    = WRKFLO::VERSION
 
   opts.on("-b", "--backward", "Reverse step order and undo compatible steps") do |b|
     options[:backward] = b
@@ -44,7 +44,7 @@ Notifier.error_out('No project specified.') if project_name.nil?
 
 # An object representation of the entire wrkflo profile, merged with
 # the options given for this run.
-wrkflo = WrkFlo.new(options)
+wrkflo = WRKFLO::WrkFlo.new(options)
 # The project workflow to execute on this run.
 project = wrkflo[project_name]
 # If no project was specified, notify and exit

--- a/lib/wrkflo.rb
+++ b/lib/wrkflo.rb
@@ -1,0 +1,13 @@
+require 'os'
+
+require 'wrkflo/version'
+require 'wrkflo/notifier'
+
+require 'wrkflo/configurable/property'
+require 'wrkflo/configurable'
+
+require 'wrkflo/profile'
+require 'wrkflo/step'
+require 'wrkflo/project'
+
+require 'wrkflo/wrkflo'

--- a/lib/wrkflo/configurable.rb
+++ b/lib/wrkflo/configurable.rb
@@ -1,56 +1,56 @@
-require 'wrkflo/configurable/property'
-
-module Configurable
-  module ClassMethods
-    # A list of properties defined by the owner
-    def properties
-      @properties ||= {}
-    end
-
-    # Define a new property for the owning object
-    def property name, required: false, type: Object, default: nil
-      properties[name] = Property.new(name, required, type, default)
-    end
-  end
-
-  def self.included base
-    base.extend ClassMethods
-  end
-
-
-  def apply_configuration raw_config
-    final_config = self.class.properties.each.with_object({}) do |(name, prop), h|
-      provided_value = raw_config[name.to_s]
-      # Determine the real value based on the property's definition
-      real_value = prop.resolve_value(provided_value)
-      # Remember the real value in the actual configuration
-      h[name.to_sym] = real_value
-    end
-
-    # Create a struct from the configuration hash to enable dot-access.
-    @configuration = Struct.new(*final_config.keys).new(*final_config.values)
-  end
-
-  # Returns `true` if the configuration is valid. Otherwise, returns a pair
-  # of the property and a reason. If a block is given, this pair is also
-  # passed to the block.
-  def validate_configuration
-    self.class.properties.values.each do |prop|
-      if prop.required?
-        unless config.respond_to?(prop.name)
-          return [prop, nil, :required].tap{ |f| yield f if block_given? }
-        end
+module WRKFLO
+  module Configurable
+    module ClassMethods
+      # A list of properties defined by the owner
+      def properties
+        @properties ||= {}
       end
 
-      value = config.send(prop.name)
-
-      return [prop, value, :type].tap{ |f| yield f if block_given? } unless prop.matches_type?(value)
+      # Define a new property for the owning object
+      def property name, required: false, type: Object, default: nil
+        properties[name] = Property.new(name, required, type, default)
+      end
     end
 
-    return true
-  end
+    def self.included base
+      base.extend ClassMethods
+    end
 
-  def config
-    @configuration
+
+    def apply_configuration raw_config
+      final_config = self.class.properties.each.with_object({}) do |(name, prop), h|
+        provided_value = raw_config[name.to_s]
+        # Determine the real value based on the property's definition
+        real_value = prop.resolve_value(provided_value)
+        # Remember the real value in the actual configuration
+        h[name.to_sym] = real_value
+      end
+
+      # Create a struct from the configuration hash to enable dot-access.
+      @configuration = Struct.new(*final_config.keys).new(*final_config.values)
+    end
+
+    # Returns `true` if the configuration is valid. Otherwise, returns a pair
+    # of the property and a reason. If a block is given, this pair is also
+    # passed to the block.
+    def validate_configuration
+      self.class.properties.values.each do |prop|
+        if prop.required?
+          unless config.respond_to?(prop.name)
+            return [prop, nil, :required].tap{ |f| yield f if block_given? }
+          end
+        end
+
+        value = config.send(prop.name)
+
+        return [prop, value, :type].tap{ |f| yield f if block_given? } unless prop.matches_type?(value)
+      end
+
+      return true
+    end
+
+    def config
+      @configuration
+    end
   end
 end

--- a/lib/wrkflo/configurable/property.rb
+++ b/lib/wrkflo/configurable/property.rb
@@ -1,70 +1,72 @@
-module Configurable
-  class Property
-    # The name of the property as it should appear in the configuration
-    attr_accessor :name
-    # Whether the property is required to be provided by the user
-    attr_accessor :required
-    alias_method  :required?, :required
-    # The expected type of the value
-    attr_accessor :type
-    # The default value to be given to this property if one is not provided
-    attr_accessor :default
+module WRKFLO
+  module Configurable
+    class Property
+      # The name of the property as it should appear in the configuration
+      attr_accessor :name
+      # Whether the property is required to be provided by the user
+      attr_accessor :required
+      alias_method  :required?, :required
+      # The expected type of the value
+      attr_accessor :type
+      # The default value to be given to this property if one is not provided
+      attr_accessor :default
 
 
-    def initialize name, is_required, expected_type, default_value
-      @name     = name
-      @required = is_required
-      @default  = default_value
-      @type     = expected_type
-    end
+      def initialize name, is_required, expected_type, default_value
+        @name     = name
+        @required = is_required
+        @default  = default_value
+        @type     = expected_type
+      end
 
 
-    # Assign a value to this property
-    def resolve_value value
-      value.nil? ? @default : value
-    end
+      # Assign a value to this property
+      def resolve_value value
+        value.nil? ? @default : value
+      end
 
-    # Returns true if `value` is of the type expected by this property. Returns
-    # false otherwise.
-    # For simple types, this is a simple `is_a?` check.
-    # For arrays, two different rules apply:
-    #   - `Array[]` expects an arbitrary array of values.
-    #   - `Array[Float]` expects an arbitrary-length array of `Float` values.
-    #   - `Array[Float, String, ...]` expects an Array of exactly those types.
-    def matches_type? value, expected_type: type
-      case expected_type
-      # Raw class types
-      when Array
-        case expected_type.length
-        when 0
-          return value.is_a?(Array)
-        when 1
-          return value.all?{ |v| matches_type?(v, expected_type: expected_type[0]) }
+      # Returns true if `value` is of the type expected by this property. Returns
+      # false otherwise.
+      # For simple types, this is a simple `is_a?` check.
+      # For arrays, two different rules apply:
+      #   - `Array[]` expects an arbitrary array of values.
+      #   - `Array[Float]` expects an arbitrary-length array of `Float` values.
+      #   - `Array[Float, String, ...]` expects an Array of exactly those types.
+      def matches_type? value, expected_type: type
+        case expected_type
+        # Raw class types
+        when Array
+          case expected_type.length
+          when 0
+            return value.is_a?(Array)
+          when 1
+            return value.all?{ |v| matches_type?(v, expected_type: expected_type[0]) }
+          else
+            return expected_type.zip([value].flatten(1)).all?{ |t, v| matches_type?(v, expected_type: t) }
+          end
         else
-          return expected_type.zip([value].flatten(1)).all?{ |t, v| matches_type?(v, expected_type: t) }
+          value.is_a?(expected_type)
         end
-      else
-        value.is_a?(expected_type)
       end
-    end
 
-    def type_as_string expected_type: type
-      case expected_type
-      when Array
-        value_types = expected_type.map{ |t| t.to_s }
-        "Array[#{value_types.join(',')}]"
-      else
-        expected_type.to_s
+      def type_as_string expected_type: type
+        case expected_type
+        when Array
+          value_types = expected_type.map{ |t| t.to_s }
+          "Array[#{value_types.join(',')}]"
+        else
+          expected_type.to_s
+        end
       end
-    end
 
-    def value_type_as_string value
-      case value
-      when Array
-        value_types = value.map{ |v| v.class.to_s }
-        "Array[#{value_types.join(',')}]"
-      else
-        value.class.to_s
+      def value_type_as_string value
+        case value
+        when Array
+          value_types = value.map{ |v| v.class.to_s }
+          "Array[#{value_types.join(',')}]"
+        else
+          value.class.to_s
+        end
       end
     end
   end

--- a/lib/wrkflo/notifier.rb
+++ b/lib/wrkflo/notifier.rb
@@ -1,19 +1,21 @@
-module Notifier
-  FOOTER_TEXT = <<-END_FOOTER
+module WRKFLO
+  module Notifier
+    FOOTER_TEXT = <<-END_FOOTER
 Run `wrkflo --help` for usage information.
-  END_FOOTER
+    END_FOOTER
 
-  # Write an error message to stderr and abort execution, exiting with the
-  # given status code, or `1` if no status code is specified.
-  def self.error_out *messages, type: "Error", status: 1
-    $stderr.puts "#{type}: #{messages.first}"
-    messages.drop(1).each{ |msg| $stderr.puts "\t#{msg}" }
-    $stderr.puts FOOTER_TEXT
-    exit status
-  end
+    # Write an error message to stderr and abort execution, exiting with the
+    # given status code, or `1` if no status code is specified.
+    def self.error_out *messages, type: "Error", status: 1
+      $stderr.puts "#{type}: #{messages.first}"
+      messages.drop(1).each{ |msg| $stderr.puts "\t#{msg}" }
+      $stderr.puts FOOTER_TEXT
+      exit status
+    end
 
-  # Write an arbitrary message to stdout.
-  def self.log message
-    $stdout.puts message
+    # Write an arbitrary message to stdout.
+    def self.log message
+      $stdout.puts message
+    end
   end
 end

--- a/lib/wrkflo/profile.rb
+++ b/lib/wrkflo/profile.rb
@@ -1,11 +1,13 @@
-class Profile
-  def self.load source
-    @projects = YAML.load_file(source)
-    @options = @projects.delete("options")
-  rescue
-    Notifier.error_out("Could not load configuration at '#{source}'.", type: "ConfigurationError")
-  end
+module WRKFLO
+  class Profile
+    def self.load source
+      @projects = YAML.load_file(source)
+      @options = @projects.delete("options")
+    rescue
+      Notifier.error_out("Could not load configuration at '#{source}'.", type: "ConfigurationError")
+    end
 
-  def self.projects;  @projects;  end
-  def self.options;   @options;   end
+    def self.projects;  @projects;  end
+    def self.options;   @options;   end
+  end
 end

--- a/lib/wrkflo/project.rb
+++ b/lib/wrkflo/project.rb
@@ -1,67 +1,67 @@
-require 'wrkflo/step'
+module WRKFLO
+  class Project
+    attr_accessor :name, :steps
 
-class Project
-  attr_accessor :name, :steps
-
-  def initialize name
-    # The name of this project workflow
-    @name         = name
-    # The raw configuration used by this project
-    @config       = Profile.projects[@name]
-    # The steps that make up this workflow
-    @steps        = @config.map{ |name, conf| Step.create(name, conf, self) }
-    # The step currently being executed
-    @current_step = 0
-  end
-
-  # Run each step in the order they are specified
-  def run
-    meta_log "Running workflow '#{@name}'"
-    # Reset the current step number
-    @current_step_num = 0
-    # Run the steps
-    @steps.each do |step|
-      # Remember the step being run
-      @current_step = step
-      # Increment the current step so that the first step is 1
-      @current_step_num += 1
-      # Run the step
-      @current_step.setup
-      @current_step.run
+    def initialize name
+      # The name of this project workflow
+      @name         = name
+      # The raw configuration used by this project
+      @config       = Profile.projects[@name]
+      # The steps that make up this workflow
+      @steps        = @config.map{ |name, conf| Step.create(name, conf, self) }
+      # The step currently being executed
+      @current_step = 0
     end
 
-    meta_log "Workflow complete"
-  end
+    # Run each step in the order they are specified
+    def run
+      meta_log "Running workflow '#{@name}'"
+      # Reset the current step number
+      @current_step_num = 0
+      # Run the steps
+      @steps.each do |step|
+        # Remember the step being run
+        @current_step = step
+        # Increment the current step so that the first step is 1
+        @current_step_num += 1
+        # Run the step
+        @current_step.setup
+        @current_step.run
+      end
 
-  # Undo the steps in reverse order
-  def unrun
-    meta_log "Reversing workflow '#{@name}'"
-    # Reset the current step number
-    @current_step_num = @steps.size
-    # Run the steps
-    @steps.each do |step|
-      # Track the step being run
-      @current_step = step
-      # Run the step
-      @current_step.setup
-      @current_step.unrun
-      # Decrement the current step so that the last step is 1
-      @current_step_num -= 1
+      meta_log "Workflow complete"
     end
 
-    meta_log "Workflow reversed"
-  end
+    # Undo the steps in reverse order
+    def unrun
+      meta_log "Reversing workflow '#{@name}'"
+      # Reset the current step number
+      @current_step_num = @steps.size
+      # Run the steps
+      @steps.each do |step|
+        # Track the step being run
+        @current_step = step
+        # Run the step
+        @current_step.setup
+        @current_step.unrun
+        # Decrement the current step so that the last step is 1
+        @current_step_num -= 1
+      end
 
-  # Post a message to the terminal with some identifying information
-  def log message
-    puts "  - Step ##{@current_step_num} (#{@current_step.name}): #{message}"
-  end
-
-
-  private
-    # Write a log message with a different prefix marker to visually
-    # indicate a meta-type message
-    def meta_log message
-      puts ">> #{message}"
+      meta_log "Workflow reversed"
     end
+
+    # Post a message to the terminal with some identifying information
+    def log message
+      puts "  - Step ##{@current_step_num} (#{@current_step.name}): #{message}"
+    end
+
+
+    private
+      # Write a log message with a different prefix marker to visually
+      # indicate a meta-type message
+      def meta_log message
+        puts ">> #{message}"
+      end
+  end
 end

--- a/lib/wrkflo/step.rb
+++ b/lib/wrkflo/step.rb
@@ -1,97 +1,96 @@
-require 'os'
-require 'wrkflo/configurable'
+module WRKFLO
+  class Step
+    attr_accessor :name, :raw_config, :project
 
-class Step
-  attr_accessor :name, :raw_config, :project
+    # A hash of step aliases to their respective classes. This map determines
+    # the class that a given step in a project will be transformed into.
+    @@step_map = { }
 
-  # A hash of step aliases to their respective classes. This map determines
-  # the class that a given step in a project will be transformed into.
-  @@step_map = { }
+    class << self
+      # Add an alias for this class to the step map. Used by subclasses to
+      # register their definitions
+      def add_alias name
+        @@step_map[name.to_sym] = self
+      end
 
-  class << self
-    # Add an alias for this class to the step map. Used by subclasses to
-    # register their definitions
-    def add_alias name
-      @@step_map[name.to_sym] = self
-    end
-
-    # Create a new instance of a Step based on the step map entry. If none
-    # exists, a generic Step is created.
-    def create name='', config={}, project=nil
-      @@step_map[name.to_sym].new(name, config, project) || Step.new(name, config, project)
-    end
-  end
-
-
-  include Configurable
-
-
-  def initialize name, raw_config, project=nil
-    # The name for this step
-    @name = name
-    # The options that define this step
-    @raw_config = raw_config
-    # The project to which this step belongs
-    @project = project
-    # Generate the finalized step configuration
-    apply_configuration(@raw_config)
-    # Always validate the new configuration unless specifically told not to.
-    ensure_valid_configuration
-    # Run step-specific initialization
-    init
-  end
-
-  # A pass through to this step's project's log. If this step has no project,
-  # a simple puts call is used instead.
-  def log message
-    @project ? @project.log(message) : puts(message)
-  end
-
-
-  # STEP METHODS
-  #
-  # These methods should be defined by all Step subclasses as given by their
-  # descriptions.
-
-  # Work done immediately after initializing this step
-  def init;   end
-  # Common work done before running and unrunning.
-  def setup;  end
-  # The code to run when running this step normally
-  def run
-    log "Nothing to do."
-  end
-  # The code to run when running this step backwards
-  def unrun
-    log "Nothing to do."
-  end
-
-
-  protected
-
-    # Return true if being run on the given platform. If a block is given, run
-    # the block only if being run on the given platform and return the result.
-    def on platform
-      return OS.send("#{platform}?").tap{ |yn| yield yn if block_given? }
-    end
-
-
-  private
-
-    def ensure_valid_configuration
-      validate_configuration do |prop, value, reason|
-        prop_name = "`#{@name}.#{prop.name}`"
-        case reason
-        when :required
-          Notifier.error_out("required property #{prop_name} not provided for `#{@project.name}`.", type: "ConfigurationError")
-        when :type
-          Notifier.error_out(
-            "property #{prop_name} for `#{@project.name}` does not match expected type.",
-            "expected: #{prop.type_as_string}",
-            "got:      #{prop.value_type_as_string(value)}")
-        else
-          Notifier.error_out("Unknown error", type: "ConfigurationError")
-        end
+      # Create a new instance of a Step based on the step map entry. If none
+      # exists, a generic Step is created.
+      def create name='', config={}, project=nil
+        @@step_map[name.to_sym].new(name, config, project) || Step.new(name, config, project)
       end
     end
+
+
+    include Configurable
+
+
+    def initialize name, raw_config, project=nil
+      # The name for this step
+      @name = name
+      # The options that define this step
+      @raw_config = raw_config
+      # The project to which this step belongs
+      @project = project
+      # Generate the finalized step configuration
+      apply_configuration(@raw_config)
+      # Always validate the new configuration unless specifically told not to.
+      ensure_valid_configuration
+      # Run step-specific initialization
+      init
+    end
+
+    # A pass through to this step's project's log. If this step has no project,
+    # a simple puts call is used instead.
+    def log message
+      @project ? @project.log(message) : puts(message)
+    end
+
+
+    # STEP METHODS
+    #
+    # These methods should be defined by all Step subclasses as given by their
+    # descriptions.
+
+    # Work done immediately after initializing this step
+    def init;   end
+    # Common work done before running and unrunning.
+    def setup;  end
+    # The code to run when running this step normally
+    def run
+      log "Nothing to do."
+    end
+    # The code to run when running this step backwards
+    def unrun
+      log "Nothing to do."
+    end
+
+
+    protected
+
+      # Return true if being run on the given platform. If a block is given, run
+      # the block only if being run on the given platform and return the result.
+      def on platform
+        return OS.send("#{platform}?").tap{ |yn| yield yn if block_given? }
+      end
+
+
+    private
+
+      def ensure_valid_configuration
+        validate_configuration do |prop, value, reason|
+          prop_name = "`#{@name}.#{prop.name}`"
+          case reason
+          when :required
+            Notifier.error_out("required property #{prop_name} not provided for `#{@project.name}`.", type: "ConfigurationError")
+          when :type
+            Notifier.error_out(
+              "property #{prop_name} for `#{@project.name}` does not match expected type.",
+              "expected: #{prop.type_as_string}",
+              "got:      #{prop.value_type_as_string(value)}")
+          else
+            Notifier.error_out("Unknown error", type: "ConfigurationError")
+          end
+        end
+      end
+  end
 end

--- a/lib/wrkflo/steps/atom.rb
+++ b/lib/wrkflo/steps/atom.rb
@@ -1,10 +1,12 @@
-class AtomStep < Step
-  add_alias :atom
+module WRKFLO
+  class AtomStep < Step
+    add_alias :atom
 
-  property :path, required: true, type: String
+    property :path, required: true, type: String
 
-  def run
-    log "Opening an Atom Window at  #{config.path}"
-    `atom #{config.path}`
+    def run
+      log "Opening an Atom Window at  #{config.path}"
+      `atom #{config.path}`
+    end
   end
 end

--- a/lib/wrkflo/steps/editor.rb
+++ b/lib/wrkflo/steps/editor.rb
@@ -1,15 +1,17 @@
-class Editor < Step
-  add_alias :editor
+module WRKFLO
+  class Editor < Step
+    add_alias :editor
 
-  property :which,  required: false,  type: String, default: Profile.options['editor']
-  property :path,   required: true,   type: String
+    property :which,  required: false,  type: String, default: Profile.options['editor']
+    property :path,   required: true,   type: String
 
-  def init
-    @editor = config.which
-    @step = Step.create(@editor.to_sym, @raw_config, project)
-    @name = "editor[#{@step.name}]"
+    def init
+      @editor = config.which
+      @step = Step.create(@editor.to_sym, @raw_config, project)
+      @name = "editor[#{@step.name}]"
+    end
+
+    def run;    @step.run;    end
+    def unrun;  @step.unrun;  end
   end
-
-  def run;    @step.run;    end
-  def unrun;  @step.unrun;  end
 end

--- a/lib/wrkflo/steps/emacs.rb
+++ b/lib/wrkflo/steps/emacs.rb
@@ -1,10 +1,12 @@
-class EmacsStep < Step
-  add_alias :emacs
+module WRKFLO
+  class EmacsStep < Step
+    add_alias :emacs
 
-  property :path, required: true, type: String
+    property :path, required: true, type: String
 
-  def run
-    log "Opening an Emacs frame at #{config.path}"
-    `emacsclient -c -a "" -n #{config.path}`
+    def run
+      log "Opening an Emacs frame at #{config.path}"
+      `emacsclient -c -a "" -n #{config.path}`
+    end
   end
 end

--- a/lib/wrkflo/steps/filesystem.rb
+++ b/lib/wrkflo/steps/filesystem.rb
@@ -1,18 +1,20 @@
-class FileSystem < Step
-  add_alias :filesystem
-  add_alias :fs
+module WRKFLO
+  class FileSystem < Step
+    add_alias :filesystem
+    add_alias :fs
 
-  property :which,        required: false,  type: String, default: Profile.options['filesystem']
-  property :host,         required: true,   type: String
-  property :remote_path,  required: true,   type: String
-  property :local_path,   required: true,   type: String
+    property :which,        required: false,  type: String, default: Profile.options['filesystem']
+    property :host,         required: true,   type: String
+    property :remote_path,  required: true,   type: String
+    property :local_path,   required: true,   type: String
 
-  def init
-    @filesystem = config.which
-    @step = Step.create(@filesystem.to_sym, @raw_config, project)
-    @name = "filesystem[#{@step.name}]"
+    def init
+      @filesystem = config.which
+      @step = Step.create(@filesystem.to_sym, @raw_config, project)
+      @name = "filesystem[#{@step.name}]"
+    end
+
+    def run;    @step.run;    end
+    def unrun;  @step.unrun;  end
   end
-
-  def run;    @step.run;    end
-  def unrun;  @step.unrun;  end
 end

--- a/lib/wrkflo/steps/ssh.rb
+++ b/lib/wrkflo/steps/ssh.rb
@@ -1,13 +1,15 @@
-class SSHStep < Step
-  add_alias :ssh
+module WRKFLO
+  class SSHStep < Step
+    add_alias :ssh
 
-  property :host,       required: true, type: String
-  property :directory,  required: true, type: String
+    property :host,       required: true, type: String
+    property :directory,  required: true, type: String
 
-  def run
-    log "SSHing into  #{config.host}  at  #{config.directory}"
+    def run
+      log "SSHing into  #{config.host}  at  #{config.directory}"
 
-    ssh_command = "ssh -t #{config.host} \\\"#{config.directory}; bash --login\\\""
-    `osascript -e 'tell application "Terminal" to activate' -e 'tell application "System Events" to tell process "Terminal" to keystroke "t" using command down' -e 'tell application "Terminal" to do script "#{ssh_command}" in selected tab of the front window'`
+      ssh_command = "ssh -t #{config.host} \\\"#{config.directory}; bash --login\\\""
+      `osascript -e 'tell application "Terminal" to activate' -e 'tell application "System Events" to tell process "Terminal" to keystroke "t" using command down' -e 'tell application "Terminal" to do script "#{ssh_command}" in selected tab of the front window'`
+    end
   end
 end

--- a/lib/wrkflo/steps/sshfs.rb
+++ b/lib/wrkflo/steps/sshfs.rb
@@ -1,17 +1,19 @@
-class SSHFSStep < Step
-  add_alias :sshfs
+module WRKFLO
+  class SSHFSStep < Step
+    add_alias :sshfs
 
-  property :host,         required: true, type: String
-  property :remote_path,  required: true, type: String
-  property :local_path,   required: true, type: String
+    property :host,         required: true, type: String
+    property :remote_path,  required: true, type: String
+    property :local_path,   required: true, type: String
 
-  def run
-    log "Mounting  #{config.host}:#{config.remote_path}  at  #{config.local_path}"
-    `sshfs #{config.host}:#{config.remote_path} #{config.local_path}`
-  end
+    def run
+      log "Mounting  #{config.host}:#{config.remote_path}  at  #{config.local_path}"
+      `sshfs #{config.host}:#{config.remote_path} #{config.local_path}`
+    end
 
-  def unrun
-    log "Unmounting  #{config.host}:#{config.remote_path}  from  #{config.local_path}"
-    `umount #{config.local_path}`
+    def unrun
+      log "Unmounting  #{config.host}:#{config.remote_path}  from  #{config.local_path}"
+      `umount #{config.local_path}`
+    end
   end
 end

--- a/lib/wrkflo/steps/sublime.rb
+++ b/lib/wrkflo/steps/sublime.rb
@@ -1,11 +1,13 @@
-class SublimeStep < Step
-  add_alias :sublime
-  add_alias :subl
+module WRKFLO
+  class SublimeStep < Step
+    add_alias :sublime
+    add_alias :subl
 
-  property :path, required: true, type: String
+    property :path, required: true, type: String
 
-  def run
-    log "Opening a Sublime Window at  #{config.path}"
-    `subl -n #{config.path}`
+    def run
+      log "Opening a Sublime Window at  #{config.path}"
+      `subl -n #{config.path}`
+    end
   end
 end

--- a/lib/wrkflo/version.rb
+++ b/lib/wrkflo/version.rb
@@ -1,3 +1,3 @@
-module Wrkflo
+module WRKFLO
   VERSION = '0.1.0'
 end

--- a/lib/wrkflo/wrkflo.rb
+++ b/lib/wrkflo/wrkflo.rb
@@ -1,54 +1,51 @@
-require 'wrkflo/notifier'
-require 'wrkflo/version'
-require 'wrkflo/profile'
-require 'wrkflo/project'
+module WRKFLO
+  class WrkFlo
+    attr_accessor :direction, :profile, :profile_source
 
-class WrkFlo
-  attr_accessor :direction, :profile, :profile_source
+    DEFAULT_STEP_PATHS = [
+      File.join(__dir__, 'steps'),
+      File.join(ENV['HOME'], '.wrkflo', 'steps'),
+      File.join('.', '.wrkflo', 'steps')
+    ]
 
-  DEFAULT_STEP_PATHS = [
-    File.join(__dir__, 'steps'),
-    File.join(ENV['HOME'], '.wrkflo', 'steps'),
-    File.join('.', '.wrkflo', 'steps')
-  ]
+    def initialize options
+      @profile_source = options[:profile]
+      Profile.load(@profile_source)
+      load_step_definitions
+      @direction = options[:backward] ? :backward : :forward
+    end
 
-  def initialize options
-    @profile_source = options[:profile]
-    Profile.load(@profile_source)
-    load_step_definitions
-    @direction = options[:backward] ? :backward : :forward
-  end
+    # Load all step definitions from various default and configured paths.
+    def load_step_definitions
+      # For the default directories, try to scan them if they exist.
+      DEFAULT_STEP_PATHS.each do |path|
+        if Dir.exists?(path)
+          Dir[File.join(path, '*')].each{ |step_file| require step_file }
+        end
+      end
 
-  # Load all step definitions from various default and configured paths.
-  def load_step_definitions
-    # For the default directories, try to scan them if they exist.
-    DEFAULT_STEP_PATHS.each do |path|
-      if Dir.exists?(path)
-        Dir[File.join(path, '*')].each{ |step_file| require step_file }
+      # For configured paths, try to require each entry and error out if one is
+      # not available.
+      configured_step_paths.each do |path|
+        if Dir.exists?(path)
+          Dir[File.join(path, '*')].each{ |step_file| require step_file }
+        else
+          require path
+        end
       end
     end
 
-    # For configured paths, try to require each entry and error out if one is
-    # not available.
-    configured_step_paths.each do |path|
-      if Dir.exists?(path)
-        Dir[File.join(path, '*')].each{ |step_file| require step_file }
-      else
-        require path
+    # Get a specific project out of the profile. If the profile does not define
+    # the given project, return nil.
+    def [] project
+      Project.new(project) if Profile.projects[project]
+    end
+
+
+    private
+
+      def configured_step_paths
+        Profile.options['step_definitions'] || []
       end
-    end
   end
-
-  # Get a specific project out of the profile. If the profile does not define
-  # the given project, return nil.
-  def [] project
-    Project.new(project) if Profile.projects[project]
-  end
-
-
-  private
-
-    def configured_step_paths
-      Profile.options['step_definitions'] || []
-    end
 end

--- a/wrkflo.gemspec
+++ b/wrkflo.gemspec
@@ -5,7 +5,7 @@ require 'wrkflo/version'
 
 Gem::Specification.new do |spec|
   spec.name                   = 'wrkflo'
-  spec.version                = Wrkflo::VERSION
+  spec.version                = WRKFLO::VERSION
   spec.summary                = 'Get working on things faster with predefined wrkflos.'
   spec.platform               = Gem::Platform::RUBY
   spec.required_ruby_version  = '>= 2.2.0'
@@ -15,8 +15,8 @@ Gem::Specification.new do |spec|
   spec.homepage               = 'http://github.com/faultyserver/wrkflo'
   spec.license                = 'MIT'
 
-  spec.require_paths          = ["lib", "lib/wrkflo"]
-  spec.files                  += Dir['lib/wrkflo/*'] + Dir['lib/wrkflo/**/*']
+  spec.require_paths          = ["lib"]
+  spec.files                  += Dir['lib/*'] + Dir['lib/wrkflo/*'] + Dir['lib/wrkflo/**/*']
 
   spec.add_dependency         "os", "~> 1.0"
 


### PR DESCRIPTION
In the case users want to include `wrkflo` in their projects, having a namespace ensures that there (mostly) won't be any name collisions. Should a collision occur, it is simpler to rename the namespace on load to solve the collision than having to rename individual classes.

All-caps is the least awkward stylization of `wrkflo` (over `Wrkflo` and `WrkFlo`, among others).