### PR TITLE
Add Vagrant step

### DIFF
--- a/lib/wrkflo/configurable.rb
+++ b/lib/wrkflo/configurable.rb
@@ -19,7 +19,7 @@ module WRKFLO
 
     def apply_configuration raw_config
       final_config = self.class.properties.each.with_object({}) do |(name, prop), h|
-        provided_value = raw_config[name.to_s]
+        provided_value = raw_config[name.to_s] rescue nil
         # Determine the real value based on the property's definition
         real_value = prop.resolve_value(provided_value)
         # Remember the real value in the actual configuration

--- a/lib/wrkflo/steps/vagrant.rb
+++ b/lib/wrkflo/steps/vagrant.rb
@@ -1,0 +1,46 @@
+module WRKFLO
+  class VagrantStep < Step
+    add_alias :vagrant
+
+    property :name,         required: false,                default: nil
+    property :vagrant_dir,  required: false, type: String,  default: Profile.options['vagrant_dir']
+    property :up_command,   required: false, type: String,  default: 'up'
+    property :down_command, required: false, type: String,  default: 'nothing'
+
+    def init
+      # If no name is specified, use the directory as a psuedonym.
+      config.name ||= "@#{config.vagrant_dir}"
+    end
+
+
+    def run
+      log "Ensuring vagrant machine  `#{config.name}`  is up"
+      vagrant config.up_command
+    end
+
+    def unrun
+      case config.down_command
+      when 'halt'
+        log "Halting vagrant machine  `#{config.name}`."
+        vagrant 'halt'
+      when 'suspend'
+        log "Suspending vagrant machine  `#{config.name}`."
+        vagrant 'suspend'
+      when 'destroy'
+        log "Destroying vagrant machine  `#{config.name}`."
+        vagrant 'destroy'
+      when 'nothing'
+        log "Nothing to do."
+      else
+        log "Unknown vagrant command  `#{config.down_command}`."
+      end
+    end
+
+
+    private
+
+      def vagrant command
+        `VAGRANT_CWD=#{config.vagrant_dir} vagrant #{command}`
+      end
+  end
+end


### PR DESCRIPTION
The `vagrant` step allows users to ensure their virtual machines are running before continuing with a wrkflo. This is particularly useful for flows that mount/ssh into virtual machines as somewhat of a guarantee that the flow will succeed, rather than depending on the VM to already be running before starting the flow.

Note that in most cases (by default), this step will not actually do anything, as the VM will likely already be running, and running backwards defaults to doing nothing (to avoid wasteful bringing up/down machines every time).

A sample configuration using this step could be:

```yaml
options:
  vagrant_dir: ~/Sites/lendkey2/

remote:
  vagrant:
    on_down: suspend
  ssh:
    host: my-vm
    directory: cd ~
```